### PR TITLE
Add optional dailyFactoryOptions

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -8,6 +8,7 @@ import Daily, {
   DailyEventObjectRemoteParticipantsAudioLevel,
   DailyEventObjectSelectedDevicesUpdated,
   DailyEventObjectTrack,
+  DailyFactoryOptions,
   DailyParticipant,
 } from "@daily-co/daily-js";
 import {
@@ -26,15 +27,21 @@ export interface DailyTransportAuthBundle {
   token: string;
 }
 
+export interface DailyTransportConstructorOptions {
+  dailyFactoryOptions?: DailyFactoryOptions;
+}
+
 export class DailyTransport extends Transport {
   private declare _daily: DailyCall;
+  private _dailyFactoryOptions: DailyFactoryOptions;
   private _botId: string = "";
   private _selectedCam: MediaDeviceInfo | Record<string, never> = {};
   private _selectedMic: MediaDeviceInfo | Record<string, never> = {};
   private _selectedSpeaker: MediaDeviceInfo | Record<string, never> = {};
 
-  constructor() {
+  constructor({ dailyFactoryOptions = {} }: DailyTransportConstructorOptions = {}) {
     super();
+    this._dailyFactoryOptions = dailyFactoryOptions;
   }
 
   public initialize(
@@ -50,10 +57,12 @@ export class DailyTransport extends Transport {
     }
 
     this._daily = Daily.createCallObject({
-      startVideoOff: !(options.enableCam == true),
+      ...this._dailyFactoryOptions,
+      // Default is cam off
+      startVideoOff: options.enableCam != true,
+      // Default is mic on
       startAudioOff: options.enableMic == false,
       allowMultipleCallInstances: true,
-      dailyConfig: {},
     });
 
     this.attachEventListeners();


### PR DESCRIPTION
This PR proposes a new optional constructor argument for the `DailyTransport` class.
The `dailyFactoryOptions` parameter is meant to give RTVI/Pipecat developers more fine-grained control over the transport layer configuration.
For Open Sesame I'm interested to configure Daily to store selected devices in cookies, which needs to be configured on the DailyTransport.